### PR TITLE
Fix player acceleration reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,6 +574,13 @@
             gameSpeed = 2;
             gameTime = 0;
 
+            // Zerar velocidades e estados das teclas para evitar aceleração inesperada
+            player.dx = 0;
+            player.dy = 0;
+            for (const key in keys) {
+                keys[key] = false;
+            }
+
             player.x = canvas.width / 2 - player.width / 2;
             player.y = canvas.height - 70;
             player.bullets = [];


### PR DESCRIPTION
## Summary
- reset key states and player velocity on game restart to avoid unwanted acceleration

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842e61b5e9c832f812bd378815ba644