### PR TITLE
Fix player acceleration reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,14 +521,21 @@
             fuelStations.forEach(drawFuelStation);
         }
 
+        let animationFrameId;
+
         function gameLoop() {
             if (gameState === 'paused') {
-                requestAnimationFrame(gameLoop);
+                animationFrameId = requestAnimationFrame(gameLoop);
                 return;
             }
+
+            if (gameState !== 'playing') {
+                return; // Evita múltiplos loops quando o jogo não está ativo
+            }
+
             updateGame();
             drawGame();
-            requestAnimationFrame(gameLoop);
+            animationFrameId = requestAnimationFrame(gameLoop);
         }
 
         // --- UI e Controle de Estado ---
@@ -552,14 +559,17 @@
             messageOverlay.style.display = 'none';
         }
 
-        function startGame() {
-            // A inicialização do Tone.js é feita no manipulador de eventos de tecla/botão
-            if (gameState === 'gameOver' || gameState === 'start') {
+       function startGame() {
+           // A inicialização do Tone.js é feita no manipulador de eventos de tecla/botão
+           if (gameState === 'gameOver' || gameState === 'start') {
+                if (animationFrameId) {
+                    cancelAnimationFrame(animationFrameId);
+                }
                 resetGame();
                 gameState = 'playing';
                 hideMessage();
                 if (typeof requestAnimationFrame === 'function') { // Garante que o gameLoop só comece se RAF estiver disponível
-                    gameLoop(); 
+                    animationFrameId = requestAnimationFrame(gameLoop);
                 } else {
                     console.error("requestAnimationFrame não é suportado.");
                     showMessage("Erro: seu navegador não suporta animações essenciais.", false);
@@ -573,6 +583,13 @@
             lives = 3;
             gameSpeed = 2;
             gameTime = 0;
+
+            // Zerar velocidades e estados das teclas para evitar aceleração inesperada
+            player.dx = 0;
+            player.dy = 0;
+            for (const key in keys) {
+                keys[key] = false;
+            }
 
             player.x = canvas.width / 2 - player.width / 2;
             player.y = canvas.height - 70;
@@ -601,9 +618,12 @@
             updateLives();
         }
 
-        function gameOver(reason = "Fim de Jogo!") {
-            if (gameState === 'gameOver') return; 
+       function gameOver(reason = "Fim de Jogo!") {
+            if (gameState === 'gameOver') return;
             gameState = 'gameOver';
+            if (animationFrameId) {
+                cancelAnimationFrame(animationFrameId);
+            }
             playSound('gameOver');
             showMessage(`${reason}\nPontuação Final: ${score}`, true);
         }


### PR DESCRIPTION
## Summary
- reset animation frame on start and game over
- stop duplicate loops by tracking requestAnimationFrame id

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842e61b5e9c832f812bd378815ba644